### PR TITLE
fix : tts初期化前にcardStackViewの初期化を入れる(#32)

### DIFF
--- a/app/src/main/java/com/example/place/activity/FlashCardActivity.kt
+++ b/app/src/main/java/com/example/place/activity/FlashCardActivity.kt
@@ -73,6 +73,7 @@ class FlashCardActivity : AppCompatActivity(), CardStackListener, TextToSpeech.O
         setSupportActionBar(myToolbar)
 
         quizSet = Quiz().GetQuizSet(questionNum, getInstance().quizPattern)
+        cardStackView = flashCardBinding.cardStackView
         tts = TextToSpeech(this,this)
 
         tts.setOnUtteranceProgressListener(object: UtteranceProgressListener() {
@@ -91,9 +92,6 @@ class FlashCardActivity : AppCompatActivity(), CardStackListener, TextToSpeech.O
             }
 
         })
-
-
-        cardStackView = flashCardBinding.cardStackView
 
         cardStackView.layoutManager = CardStackLayoutManager(this,this).apply {
             setOverlayInterpolator(LinearInterpolator())


### PR DESCRIPTION
ttsの初期化中にcardStackViewを使う部分があるが、tts初期化後にcardStackViewを初期化するのでタイミングによってcardStackViewがnullでエラーになる

そのためcardStackViewの初期化はttsの初期化より前に置く